### PR TITLE
Workaround to show yellow underline for tabs

### DIFF
--- a/demo/src/main/java/com/vaadin/components/gwt/polymer/client/sampler/paper/TabsSample.java
+++ b/demo/src/main/java/com/vaadin/components/gwt/polymer/client/sampler/paper/TabsSample.java
@@ -15,4 +15,23 @@ public class TabsSample extends Composite {
     public TabsSample() {
         initWidget(ourUiBinder.createAndBindUi(this));
     }
+
+    @Override
+    protected void onAttach() {
+        super.onAttach();
+
+        fixTabsSelection();
+    }
+
+    // A temporary workaround to fix the underline tab issue
+    // Not a solution.
+    private native void fixTabsSelection() /*-{
+
+      setTimeout(function(){
+
+        [].forEach.call($doc.querySelectorAll("paper-tabs"), function(tabs) {
+          tabs._onResize();
+        });
+      }, 3000);
+    }-*/;
 }

--- a/demo/src/main/java/com/vaadin/components/gwt/polymer/client/sampler/paper/TabsSample.java
+++ b/demo/src/main/java/com/vaadin/components/gwt/polymer/client/sampler/paper/TabsSample.java
@@ -4,7 +4,6 @@ import com.google.gwt.core.client.GWT;
 import com.google.gwt.uibinder.client.UiBinder;
 import com.google.gwt.user.client.ui.Composite;
 import com.google.gwt.user.client.ui.HTMLPanel;
-import com.vaadin.polymer.Polymer;
 
 public class TabsSample extends Composite {
     interface SampleUiBinder extends UiBinder<HTMLPanel, TabsSample> {
@@ -15,23 +14,4 @@ public class TabsSample extends Composite {
     public TabsSample() {
         initWidget(ourUiBinder.createAndBindUi(this));
     }
-
-    @Override
-    protected void onAttach() {
-        super.onAttach();
-
-        fixTabsSelection();
-    }
-
-    // A temporary workaround to fix the underline tab issue
-    // Not a solution.
-    private native void fixTabsSelection() /*-{
-
-      setTimeout(function(){
-
-        [].forEach.call($doc.querySelectorAll("paper-tabs"), function(tabs) {
-          tabs._onResize();
-        });
-      }, 3000);
-    }-*/;
 }

--- a/lib/com/vaadin/polymer/paper/widget/PaperTabsBase.java
+++ b/lib/com/vaadin/polymer/paper/widget/PaperTabsBase.java
@@ -1,0 +1,34 @@
+package com.vaadin.polymer.paper.widget;
+
+import com.vaadin.polymer.PolymerWidget;
+import com.vaadin.polymer.elemental.Element;
+import com.vaadin.polymer.paper.element.PaperTabsElement;
+
+/**
+ * This class will be extended by PaperTabs.java and
+ * contains a workaround to fix a problem with yellow
+ * line when a tab is selected. It happens if the tabs
+ * component is added at the very beginning to the UI.
+ */
+public abstract class PaperTabsBase extends PolymerWidget {
+
+    public PaperTabsBase(String tag, String src, String html) {
+        super(tag, src, html);
+    }
+
+    @Override
+    protected void onAttach() {
+        super.onAttach();
+        fixTabsSelection((PaperTabsElement)getElement());
+    }
+    
+    // A temporary workaround to fix the underline tab issue
+    // Not a solution.
+    private native void fixTabsSelection(Element e) /*-{
+        @com.vaadin.polymer.Polymer::onReady(*)(e, function(){
+          setTimeout(function() {
+            e._onResize();
+          }, 400);
+        });
+    }-*/;
+  }


### PR DESCRIPTION
<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/vaadin/gwt-polymer-elements/31)

<!-- Reviewable:end -->
