### PR TITLE
Fixed typographical error, changed aplication to application in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ In summary, for classic and production GWT projects it would be easier to use th
 
   ```
 
-## **Styling** your aplication.
+## **Styling** your application.
 
   Polymer uses Shadow DOM styling rules for providing scoped styling of the element’s local DOM. It supports  some extra syntax which is not understable by the GWT GSS parser.
 


### PR DESCRIPTION
@vaadin, I've corrected a typographical error in the documentation of the [gwt-polymer-elements](https://github.com/vaadin/gwt-polymer-elements) project. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/vaadin/gwt-polymer-elements/60)

<!-- Reviewable:end -->
